### PR TITLE
Fix broken compilation under MacOS

### DIFF
--- a/src/picdialog.hpp
+++ b/src/picdialog.hpp
@@ -13,11 +13,11 @@
  *
  * ============================================================ */
 
-#include <flowlayout.h>
+#include "flowlayout.h"
 #include <QDialog>
 #include <QThreadPool>
 
-#include <digikam/previewloadthread.h>
+#include "previewloadthread.h"
 
 using namespace Digikam;
 

--- a/src/plugflow.hpp
+++ b/src/plugflow.hpp
@@ -15,8 +15,8 @@
 
 #pragma once
 
-#include <digikam/dplugingeneric.h>
-#include <flowlayout.h>
+#include "dplugingeneric.h"
+#include "flowlayout.h"
 
 #define DPLUGIN_IID "org.kde.digikam.plugin.generic.FlowView"
 
@@ -27,9 +27,9 @@ namespace Cathaysia {
 class PlugSettings;
 
 class FlowPlugin : public DPluginGeneric {
-    Q_OBJECT;
-    Q_PLUGIN_METADATA(IID DPLUGIN_IID);
-    Q_INTERFACES(Digikam::DPluginGeneric);
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID DPLUGIN_IID)
+    Q_INTERFACES(Digikam::DPluginGeneric)
 
 public:
     explicit FlowPlugin(QObject* const parent = nullptr);

--- a/src/plugsettings.hpp
+++ b/src/plugsettings.hpp
@@ -14,8 +14,8 @@
  * ============================================================ */
 #pragma once
 
-#include <digikam/dplugindialog.h>
-#include <flowlayout.h>
+#include "dplugindialog.h"
+#include "flowlayout.h"
 
 class QComboBox;
 class QSpinBox;


### PR DESCRIPTION
This little patch fix the broken compilation under MacOS. This must not break Linux and Windows compilation.

You must to take a care about the way to import C++ headers for digiKam. Do not use the digikam/ prefix at all.
Also local header must always wrapped with "".

MacOS and XCode is very sensible about this.

Gilles